### PR TITLE
Allow user to get HSL values for generated base colour

### DIFF
--- a/src/GeoPattern/GeoPattern.php
+++ b/src/GeoPattern/GeoPattern.php
@@ -155,6 +155,8 @@ class GeoPattern {
       else
           $baseColor['s'] = $baseColor['s'] - $satOffset/100;
 
+      $baseColor['rgb'] = $this->hslToRGB($baseColor['h'], $baseColor['s'], $baseColor['l']);
+
       return $baseColor;
     }
 

--- a/src/GeoPattern/GeoPattern.php
+++ b/src/GeoPattern/GeoPattern.php
@@ -142,20 +142,26 @@ class GeoPattern {
     }
 
     // Generators
+    public function generateColors(){
+      $hueOffset = $this->map($this->hexVal(14, 3), 0, 4095, 0, 359);
+      $satOffset = $this->hexVal(17, 1);
+      $baseColor = $this->hexToHSL($this->baseColor);
+
+      $baseColor['h'] = $baseColor['h'] - $hueOffset;
+
+
+      if ($satOffset % 2 == 0)
+          $baseColor['s'] = $baseColor['s'] + $satOffset/100;
+      else
+          $baseColor['s'] = $baseColor['s'] - $satOffset/100;
+
+      return $baseColor;
+    }
+
     protected function generateBackground()
     {
-        $hueOffset = $this->map($this->hexVal(14, 3), 0, 4095, 0, 359);
-        $satOffset = $this->hexVal(17, 1);
-        $baseColor = $this->hexToHSL($this->baseColor);
+        $baseColor = $this->generateColors();
         $color     = $this->color;
-
-        $baseColor['h'] = $baseColor['h'] - $hueOffset;
-
-
-        if ($satOffset % 2 == 0)
-            $baseColor['s'] = $baseColor['s'] + $satOffset/100;
-        else
-            $baseColor['s'] = $baseColor['s'] - $satOffset/100;
 
         if (isset($color))
             $rgb = $this->hexToRGB($color);


### PR DESCRIPTION
Moves the colour generation into its own function that is public.

This lets the user (me) get the colour that geo pattern decided to use for the background and use it elsewhere. For my uses I wanted links on the page to match the colour of the pattern for the page title.